### PR TITLE
プロトタイプ削除機能

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -24,6 +24,9 @@ class PrototypesController < ApplicationController
   end
 
   def destroy
+    prototype = Prototype.find(params[:id])
+    prototype.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -23,6 +23,9 @@ class PrototypesController < ApplicationController
     @prototype =Prototype.find(params[:id])
   end
 
+  def destroy
+  end
+
   private
 
   def prototype_params

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -9,7 +9,7 @@
       <div class="prototype__manage">
         <% if user_signed_in? && current_user.id == @prototype.user_id %>
           <%= link_to "編集する", root_path, class: :prototype__btn %>
-          <%= link_to "削除する", root_path, class: :prototype__btn %>
+         <%= link_to "削除する", prototype_path(@prototype), method: :delete, class: :prototype__btn %>
         <% end %>
         </div>
       <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -5,14 +5,12 @@
         <%= @prototype.title %>
       </p>
       <%= link_to "by #{@prototype.user.name}", root_path, class: :prototype__user %>
-      <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
       <div class="prototype__manage">
         <% if user_signed_in? && current_user.id == @prototype.user_id %>
           <%= link_to "編集する", root_path, class: :prototype__btn %>
          <%= link_to "削除する", prototype_path(@prototype), method: :delete, class: :prototype__btn %>
         <% end %>
         </div>
-      <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>
       <div class="prototype__image">
         <%= image_tag @prototype.image %>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
 
   devise_for :users
   root to: "prototypes#index"
-  resources :prototypes, only: [:new, :create, :show]
+  resources :prototypes, only: [:new, :create, :show, :destroy]
 
 end


### PR DESCRIPTION
# What
prototypesコントローラーにdestroyアクションを設定
destroyアクションに対するルーティングをroutes.rbに記述
「削除する」ボタンから、ルーティングのdestroyアクションが呼び込まれるようにshow.html.erbファイルを設定
コントローラーでプロトタイプを削除し、トップページに戻る記述を設定

# Why
削除機能の実装のため。

# Gyazo
https://gyazo.com/d68d24df6697c9d1f46dc4c7c1fa44c8