### PR TITLE
ユーザー詳細機能の実装

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,2 @@
+class UsersController < ApplicationController
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,2 +1,4 @@
 class UsersController < ApplicationController
+	def show
+	end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,7 @@
 class UsersController < ApplicationController
+
 	def show
+		@user = User.find(params[:id])
 	end
+	
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -1,4 +1,5 @@
-<% @prototypes.each do |prototype| %>
+<%# <% @prototypes.each do |prototype| %> 
+<% prototypes.each do |prototype| %>
 <div class="card">
    <%= link_to image_tag(prototype.image, class: :card__img), prototype_path(prototype.id), method: :get %>
   <div class="card__body">
@@ -6,7 +7,7 @@
     <p class="card__summary">
       <%= prototype.catch_copy %>
     </p>
-    <%= link_to "by#{prototype.user.name}", root_path, class: :card__user %>
+    <%= link_to "by#{prototype.user.name}", user_path(prototype.user.id), method: :get, class: :card__user %>
   </div>
 </div>
 <% end %>

--- a/app/views/prototypes/index.html.erb
+++ b/app/views/prototypes/index.html.erb
@@ -3,11 +3,11 @@
     <% if user_signed_in? %>
       <div class="greeting">
          こんにちは、 
-        <%= link_to "#{current_user.name}さん", root_path, class: :greeting__link%>
+        <%= link_to "#{current_user.name}さん", user_path(current_user.id), method: :get, class: :greeting__link%>
       </div>
     <% end %>
     <div class="card__wrapper">
-      <%= render "prototype"%>
+      <%= render partial: "prototype", locals: {prototypes: @prototypes} %>
     </div>
   </div>
 </main>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -4,7 +4,7 @@
       <p class="prototype__hedding">
         <%= @prototype.title %>
       </p>
-      <%= link_to "by #{@prototype.user.name}", root_path, class: :prototype__user %>
+      <%= link_to "by #{@prototype.user.name}", user_path(@prototype.user.id), method: :get, class: :prototype__user %>
       <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
       <div class="prototype__manage">
         <% if user_signed_in? && current_user.id == @prototype.user_id %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,35 @@
+<div class="main">
+  <div class="inner">
+    <div class="user__wrapper">
+      <h2 class="page-heading">
+        <%= "ユーザー名さんの情報"%>
+      </h2>
+      <table class="table">
+        <tbody>
+          <tr>
+            <th class="table__col1">名前</th>
+            <td class="table__col2"><%= "ユーザー名" %></td>
+          </tr>
+          <tr>
+            <th class="table__col1">プロフィール</th>
+            <td class="table__col2"><%= "ユーザーのプロフィール" %></td>
+          </tr>
+          <tr>
+            <th class="table__col1">所属</th>
+            <td class="table__col2"><%= "ユーザーの所属" %></td>
+          </tr>
+          <tr>
+            <th class="table__col1">役職</th>
+            <td class="table__col2"><%= "ユーザーの役職" %></td>
+          </tr>
+        </tbody>
+      </table>
+      <h2 class="page-heading">
+        <%= "ユーザー名さんのプロトタイプ"%>
+      </h2>
+      <div class="user__card">
+        <%# 部分テンプレートでそのユーザーが投稿したプロトタイプ投稿一覧を表示する %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,33 +2,34 @@
   <div class="inner">
     <div class="user__wrapper">
       <h2 class="page-heading">
-        <%= "ユーザー名さんの情報"%>
+        <%= "#{@user.name}さんの情報"%>
       </h2>
       <table class="table">
         <tbody>
           <tr>
             <th class="table__col1">名前</th>
-            <td class="table__col2"><%= "ユーザー名" %></td>
+            <td class="table__col2"><%= @user.name %></td>
           </tr>
           <tr>
             <th class="table__col1">プロフィール</th>
-            <td class="table__col2"><%= "ユーザーのプロフィール" %></td>
+            <td class="table__col2"><%= @user.profile %></td>
           </tr>
           <tr>
             <th class="table__col1">所属</th>
-            <td class="table__col2"><%= "ユーザーの所属" %></td>
+            <td class="table__col2"><%= @user.profile %></td>
           </tr>
           <tr>
             <th class="table__col1">役職</th>
-            <td class="table__col2"><%= "ユーザーの役職" %></td>
+            <td class="table__col2"><%= @user.position  %></td>
           </tr>
         </tbody>
       </table>
       <h2 class="page-heading">
-        <%= "ユーザー名さんのプロトタイプ"%>
+        <%= "#{@user.name}さんのプロトタイプ"%>
       </h2>
       <div class="user__card">
         <%# 部分テンプレートでそのユーザーが投稿したプロトタイプ投稿一覧を表示する %>
+        <%= render partial: "prototypes/prototype", locals: {prototypes: @user.prototypes } %>
       </div>
     </div>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,33 +2,34 @@
   <div class="inner">
     <div class="user__wrapper">
       <h2 class="page-heading">
-        <%= "ユーザー名さんの情報"%>
+        <%= "#{@user.name}さんの情報"%>
       </h2>
       <table class="table">
         <tbody>
           <tr>
             <th class="table__col1">名前</th>
-            <td class="table__col2"><%= "ユーザー名" %></td>
+            <td class="table__col2"><%= @user.name %></td>
           </tr>
           <tr>
             <th class="table__col1">プロフィール</th>
-            <td class="table__col2"><%= "ユーザーのプロフィール" %></td>
+            <td class="table__col2"><%= @user.profile %></td>
           </tr>
           <tr>
             <th class="table__col1">所属</th>
-            <td class="table__col2"><%= "ユーザーの所属" %></td>
+            <td class="table__col2"><%= @user.occupation %></td>
           </tr>
           <tr>
             <th class="table__col1">役職</th>
-            <td class="table__col2"><%= "ユーザーの役職" %></td>
+            <td class="table__col2"><%= @user.position %></td>
           </tr>
         </tbody>
       </table>
       <h2 class="page-heading">
-        <%= "ユーザー名さんのプロトタイプ"%>
+        <%= "#{@user.name}さんのプロトタイプ"%>
       </h2>
       <div class="user__card">
         <%# 部分テンプレートでそのユーザーが投稿したプロトタイプ投稿一覧を表示する %>
+        <%= render partial: "prototypes/prototype", locals: {prototypes: @user.prototypes } %>
       </div>
     </div>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,34 +2,33 @@
   <div class="inner">
     <div class="user__wrapper">
       <h2 class="page-heading">
-        <%= "#{@user.name}さんの情報"%>
+        <%= "ユーザー名さんの情報"%>
       </h2>
       <table class="table">
         <tbody>
           <tr>
             <th class="table__col1">名前</th>
-            <td class="table__col2"><%= @user.name %></td>
+            <td class="table__col2"><%= "ユーザー名" %></td>
           </tr>
           <tr>
             <th class="table__col1">プロフィール</th>
-            <td class="table__col2"><%= @user.profile %></td>
+            <td class="table__col2"><%= "ユーザーのプロフィール" %></td>
           </tr>
           <tr>
             <th class="table__col1">所属</th>
-            <td class="table__col2"><%= @user.occupation %></td>
+            <td class="table__col2"><%= "ユーザーの所属" %></td>
           </tr>
           <tr>
             <th class="table__col1">役職</th>
-            <td class="table__col2"><%= @user.position %></td>
+            <td class="table__col2"><%= "ユーザーの役職" %></td>
           </tr>
         </tbody>
       </table>
       <h2 class="page-heading">
-        <%= "#{@user.name}さんのプロトタイプ"%>
+        <%= "ユーザー名さんのプロトタイプ"%>
       </h2>
       <div class="user__card">
         <%# 部分テンプレートでそのユーザーが投稿したプロトタイプ投稿一覧を表示する %>
-        <%= render partial: "prototypes/prototype", locals: {prototypes: @user.prototypes } %>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "prototypes#index"
   resources :prototypes, only: [:new, :create, :show, :destroy, :edit, :update]
+  resources :users, only: [:show]
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
usersコントローラーの作成
usersコントローラーshowアクション定義
　〃　コントローラーインスタンス変数@user定義
ルーティング追記
ビューファイル配置
TOPページ「こんにちは○○さん」、各プロトタイプ投稿者部分リンク設定
詳細ページ投稿者部分リンク設定
ユーザー詳細ページ各情報設定
collectionオプション（render）で部分テンプレート設定

※各コメント投稿者からユーザー詳細ページへの遷移はまだ（コメント機能、ユーザー管理機能、マージ後対応）

# Why
ユーザー詳細ページ実装のため。

# Gyazo
◼︎ログイン状態で、ユーザー詳細表示ページへ遷移した動画
一覧→ユーザー詳細表示ページ：https://gyazo.com/b025d848069a334b35fa9023338b7d80
一覧こんにちは名前→ユーザー詳細ページ：https://gyazo.com/f8aa83e8e33271f4410cf5493b9628f3
詳細ページ→ユーザー詳細表示ページ：https://gyazo.com/8c54c976f37bb2294f212a57ece1c69a
※レスポンスが遅くて結果見えてないんですが、ユーザー詳細表示ページに遷移しています。

◼︎ログアウト状態で、ユーザー詳細表示ページへ遷移した動画
レスポンス遅いので、画像ですみません。
【遷移確認済み】
一覧画像下の名前のリンク：https://gyazo.com/37d85d86b2cd8b7b338e6299aeebeac7
詳細画面上の名前のリンク：https://gyazo.com/ee24c8d6f3b3c70d1f25b2eff4dba545