### PR TITLE
アクセス範囲制限の実装

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,4 +1,5 @@
 class PrototypesController < ApplicationController
+  before_action :authenticate_user!, only: [:new, :edit, :destroy]
   before_action :move_to_index, only: [:edit]
 
   def index


### PR DESCRIPTION
what
プロトタイプコントローラーの編集

why
アクセス範囲制限の実装のため

ーーーーーーーーーーーーーー以下Gyazoですーーーーーーーーーーーーーーーーー

* ログアウト状態のユーザーは、プロトタイプ新規投稿ページ・プロトタイプ編集ページに遷移しようとすると、ログインページにリダイレクトされること（ページはないが、削除機能にも同様の実装を行うこと）
https://gyazo.com/cb66d5e71dc7a966197eb0247006cefd

https://gyazo.com/dce781a11d7d231ddcef22e357af6d6d

* ログアウト状態のユーザーであっても、トップページ・プロトタイプ詳細ページ・ユーザー詳細ページ・ユーザー新規登録ページ・ログインページには遷移できること
* 
* https://gyazo.com/4561053ecbda6764fd30ef509802bd88
* 
* ログイン状態のユーザーであっても、他のユーザーのプロトタイプ編集ページのURLを直接入力して遷移しようとすると、トップページにリダイレクトされること
https://gyazo.com/631c21eb091d92a76b0be048b87e6e97
